### PR TITLE
lua nginx module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 MAINTAINER Global-Solutions co. ltd.
 
-ENV NGINX_VERSION=1.11.12 \
+ENV NGINX_VERSION=1.11.10 \
     DEVEL_KIT_MODULE_VERSION=0.3.0 \
     LUA_MODULE_VERSION=0.10.7 \
     LUAJIT_LIB=/usr/lib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,14 @@ FROM alpine:3.4
 
 MAINTAINER Global-Solutions co. ltd.
 
-ENV NGINX_VERSION 1.11.12
+ENV NGINX_VERSION=1.11.12 \
+    DEVEL_KIT_MODULE_VERSION=0.3.0 \
+    LUA_MODULE_VERSION=0.10.7 \
+    LUAJIT_LIB=/usr/lib \
+    LUAJIT_INC=/usr/include/luajit-2.0
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+	&& SRCDIR="/usr/src" \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
 		--sbin-path=/usr/sbin/nginx \
@@ -50,10 +55,12 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-compat \
 		--with-file-aio \
 		--with-http_v2_module \
+		--add-module=$SRCDIR/ngx_devel_kit \
+		--add-module=$SRCDIR/lua-nginx-module \
 	" \
 	&& addgroup -S nginx \
 	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
-	&& apk add --no-cache --virtual .build-deps \
+	&& apk --update add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
 		make \
@@ -67,8 +74,13 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		gd-dev \
 		geoip-dev \
 		perl-dev \
+		luajit-dev \
+		tar \
+	&& mkdir -p $SRCDIR/ngx_devel_kit $SRCDIR/lua-nginx-module \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
+	&& curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v$DEVEL_KIT_MODULE_VERSION.tar.gz | tar -zxC $SRCDIR/ngx_devel_kit --strip-components 1 \
+	&& curl -fSL https://github.com/openresty/lua-nginx-module/archive/v$LUA_MODULE_VERSION.tar.gz | tar -zxC $SRCDIR/lua-nginx-module --strip-components 1 \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& found=''; \
 	for server in \
@@ -83,10 +95,9 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	test -z "$found" && echo >&2 "error: failed to fetch GPG key $GPG_KEYS" && exit 1; \
 	gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
 	&& rm -r "$GNUPGHOME" nginx.tar.gz.asc \
-	&& mkdir -p /usr/src \
-	&& tar -zxC /usr/src -f nginx.tar.gz \
+	&& tar -zxC $SRCDIR -f nginx.tar.gz \
 	&& rm nginx.tar.gz \
-	&& cd /usr/src/nginx-$NGINX_VERSION \
+	&& cd $SRCDIR/nginx-$NGINX_VERSION \
 	&& ./configure $CONFIG --with-debug \
 	&& make -j$(getconf _NPROCESSORS_ONLN) \
 	&& mv objs/nginx objs/nginx-debug \
@@ -113,7 +124,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
 	&& strip /usr/sbin/nginx* \
 	&& strip /usr/lib/nginx/modules/*.so \
-	&& rm -rf /usr/src/nginx-$NGINX_VERSION \
+	&& rm -rf $SRCDIR/nginx-$NGINX_VERSION \
 	\
 	# Bring in gettext so we can get `envsubst`, then throw
 	# the rest away. To do this, we need to install `gettext`


### PR DESCRIPTION
## What

* add lua nginx module
  * rollback nginx version to 1.11.10 due to compilation error
## Why

* power of lua
* reason for rollback: Nginx 1.11.11 Compilation Error · Issue #1016 · openresty/lua-nginx-module openresty/lua-nginx-module#1016

## Versions

* alpine: 3.4 
* nginx: 1.11.**10** 💣 
* ngx_devel_kit: 0.3.0
* lua-nginx-module: 0.10.7 
* luajit: 2.0