### PR TITLE
lua resty redis

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,0 +1,13 @@
+FROM gsol/nginx:1.11.10-alpine-lua
+
+MAINTAINER Global-Solutions co. ltd.
+
+ENV LUA_REDIS_VERSION=0.26 \
+    LUA_RESTY_REDIS_DIR=/opt/nginx/lua-resty-redis
+
+RUN apk --update add --no-cache --virtual .deps curl tar && \
+    mkdir $LUA_RESTY_REDIS_DIR -p && \
+    curl -fSL https://github.com/openresty/lua-resty-redis/archive/v$LUA_REDIS_VERSION.tar.gz | tar -zxC $LUA_RESTY_REDIS_DIR --strip-components 1 && \
+    apk del .deps && \
+    rm -rf /var/cache/apk/* && \
+    echo "lua_package_path '$LUA_RESTY_REDIS_DIR/lib/?.lua;;';" > /etc/nginx/conf.d/lua_resty_redis.conf


### PR DESCRIPTION
## What

- lua redis client driver

## Versions

- gsol/nginx: 1.11.10-alpine-lua
  - alpine: 3.4
  - nginx: 1.11.10
  - ngx_devel_kit: 0.3.0
  - lua-nginx-module: 0.10.7
  - luajit: 2.0
- lua-resty-redis: 0.26