### PR TITLE
bump(lua-redis): bump up nginx-lua

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,6 +1,6 @@
-FROM gsol/nginx:1.11.10-alpine-lua
+FROM gsol/nginx:1.14.0-alpine-lua
 
-MAINTAINER Global-Solutions co. ltd.
+LABEL maintainer="Global-Solutions co. ltd."
 
 ENV LUA_REDIS_VERSION=0.26 \
     LUA_RESTY_REDIS_DIR=/opt/nginx/lua-resty-redis


### PR DESCRIPTION
## What

- lua redis client driver

## Versions

- gsol/nginx: 1.14.0-alpine-lua
  - alpine: 3.7
  - nginx: 1.14.0
  - ngx_devel_kit: 0.3.0
  - lua-nginx-module: 0.10.13
  - luajit: 2.1
- lua-resty-redis: 0.26